### PR TITLE
initial support for python3 (workaround)

### DIFF
--- a/scripts/py.sh
+++ b/scripts/py.sh
@@ -18,4 +18,12 @@ python3 -m grpc_tools.protoc \
 /project/include/scalapb/scalapb.proto
 
 touch /out/__init__.py
+echo "import six
+PATH_WORKAROUND = six.PY3
+
+if PATH_WORKAROUND:
+    import sys
+    import os
+    sys.path.append(os.path.dirname(__file__))
+" > /out/__init__.py
 touch /out/scalapb/__init__.py


### PR DESCRIPTION
This is the cleanest workaround available that makes generated-python code by protoc compatible with Python 3
Tested on:
- Python 3.7.0
- Python 2.7.15


see https://github.com/dialogs/python-bot-sdk/pull/3 for more details