### PR TITLE
fix(python): remove init generation

### DIFF
--- a/scripts/py.sh
+++ b/scripts/py.sh
@@ -17,13 +17,4 @@ python3 -m grpc_tools.protoc \
 --grpc_python_out=/out \
 /project/include/scalapb/scalapb.proto
 
-touch /out/__init__.py
-echo "import six
-PATH_WORKAROUND = six.PY3
-
-if PATH_WORKAROUND:
-    import sys
-    import os
-    sys.path.append(os.path.dirname(__file__))
-" > /out/__init__.py
 touch /out/scalapb/__init__.py


### PR DESCRIPTION
This is necessary because I've discovered some problems with double import of python grpc classes. 