### PR TITLE
add new method to get referenced messages;

### DIFF
--- a/proto/messaging.proto
+++ b/proto/messaging.proto
@@ -738,6 +738,16 @@ message HistoryMessage {
     int64 random_id = 18 [(dlg).log="visible"];
 }
 
+// Content from referenced messages
+message ReferencedMessageContent {
+    UUIDValue reference_id = 1 [(dlg).log="visible"];
+    UUIDValue mid = 2 [(dlg).log="visible"];
+    int64 date = 3 [(dlg).log="visible"];
+    OutPeer sender_peer = 4;
+    OutPeer host_peer = 5 [(dlg).log="visible"];
+    MessageContent message = 6 [(dlg).log="hidden"];
+}
+
 enum ListLoadMode {
     LISTLOADMODE_UNKNOWN = 0;
     LISTLOADMODE_FORWARD = 1;

--- a/proto/sequence_and_updates.proto
+++ b/proto/sequence_and_updates.proto
@@ -314,6 +314,16 @@ message RequestSubscribeFromGroupOnline {
     repeated GroupOutPeer groups = 1 [(dlg).log="compact"];
 }
 
+message RequestGetReferencedMessages {
+    option (scalapb.message).extends = "im.dlg.grpc.GrpcRequest";
+    repeated UUIDValue reference_ids = 1 [(dlg).log="visible"];
+}
+
+message ResponseGetReferencedMessages {
+    option (scalapb.message).extends = "im.dlg.grpc.GrpcResponse";
+    repeated ReferencedMessageContent messages = 1 [(dlg).log="compact"];
+}
+
 /// Container which contains UpdateSeqUpdate
 message SeqUpdateBox {
   int32 seq = 1;
@@ -385,4 +395,8 @@ service SequenceAndUpdates {
             body: "*"
         };
     }
+
+    // Get content of referenced messages
+    // Represents state of message at the moment of reference creation
+    rpc GeReferencedMessages(RequestGetReferencedMessages) returns (ResponseGetReferencedMessages) {}
 }


### PR DESCRIPTION
Add a separate rpc call and dto to retrieve content of referenced messages, such as reply or forward.
Returns snapshot content of a referenced message at the moment of reference creation, regardless of further message modifications or deletion.

