### PR TITLE
feat: add corrupted flag to TextMessage

### DIFF
--- a/proto/messaging.proto
+++ b/proto/messaging.proto
@@ -205,6 +205,7 @@ message TextMessage {
     repeated Any extensions = 5 [(dlg).log="visible"];
     /// Mentions in message
     repeated Mention mentions = 6 [(dlg).log="visible"];
+    bool corrupted = 7 [(dlg).log="visible"];
 }
 
 message Mention {


### PR DESCRIPTION
Add corrupted flag to TextMessage in order to signal if decryption of message went unsuccessful.