### PR TITLE
Add new service ex type for signaling clients about corrupted messages

### DIFF
--- a/proto/messaging.proto
+++ b/proto/messaging.proto
@@ -293,6 +293,7 @@ message ServiceEx {
         ServiceExPhoneRejected phoneRejected = 13;
         ServiceExChatArchived chatArchived = 14;
         ServiceExChatRestored chatRestored = 15;
+        ServiceExUnableToShow unableToShow = 17;
     }
 }
 
@@ -371,6 +372,10 @@ message ServiceExChatArchived {
 
 // Message about chat restored
 message ServiceExChatRestored {
+}
+
+// Unable to show message due to server issues
+message ServiceExUnableToShow {
 }
 
 // File message


### PR DESCRIPTION
New type of service message is added, so clients would be able to show information about message decryption issues in correct locale. 