### PR TITLE
feat(messaging): add way to update message silently

### DIFF
--- a/proto/messaging.proto
+++ b/proto/messaging.proto
@@ -624,6 +624,8 @@ message UpdateMessageContentChanged {
     MessageContent message = 3 [(dlg).log="visible"];
     int64 edited_at = 5 [(dlg).log="visible"];
     int64 prev_edit_in_peer_at = 6;
+    // Update on behalf of a system, should not be displayed as edited.
+    google.protobuf.BoolValue is_silent = 7;
 }
 
 // Update about message sent


### PR DESCRIPTION
This PR aims to make messages updates display more consistent across clients and not to rely on implicit attributes like modification timestamps.

Added an explicit flag to signalize that update is created on behalf of a system and message should not be marked as 'edited'.
For now it will be used solely to create previews of links to external content.
